### PR TITLE
fix error E3314 through knatten's help in new version fuse

### DIFF
--- a/using-parse.unoproj
+++ b/using-parse.unoproj
@@ -1,6 +1,9 @@
 {
   "RootNamespace":"",
   "Packages": [
+		"Fuse.Android",
+        "Fuse.Desktop",
+        "Fuse.iOS",
         "Fuse.Animations",
         "Fuse.BasicTheme",
         "Fuse.Controls",


### PR DESCRIPTION
> E3114: There is no identifier named 'App' accessible in this scope. Did you mean 'App' (as in 'Fuse.App')? For example, try adding 'using Fuse;' to the top of the code file. Could you be missing a package reference?  

Met this error when I test the example in fuse 0.12.3 version, and Knatten through slack help me to fix it by add

```
        "Fuse.Android",
        "Fuse.Desktop",
        "Fuse.iOS",
```
